### PR TITLE
Simplified Solus installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ libsoup-2.4
 ```
 
 These can be installed on Solus by running:  
-`sudo eopkg it vala libgtk-3-devel glib2-devel libpeas-devel budgie-desktop-devel libsoup-devel`
+`sudo eopkg it vala budgie-desktop-devel libsoup-devel`
 
 ### Installing
 ```


### PR DESCRIPTION
As libgtk-3-devel and libpeas-devel are dependencies of budgie-desktop-devel, and glib2-devel is a dependency of most packages, including libpeas-devel, explicitly listing these for installation is not in fact necessary.