### PR TITLE
Fix use of weak return type in get_providers.

### DIFF
--- a/src/Backend/Uploader.vala
+++ b/src/Backend/Uploader.vala
@@ -88,7 +88,7 @@ private class Uploader : GLib.Object
         return upload_in_progress;
     }
 
-    public unowned GLib.HashTable<string, weak Providers.IProvider> get_providers() {
+    public unowned GLib.HashTable<string, Providers.IProvider> get_providers() {
         return upload_providers;
     }
 }


### PR DESCRIPTION
Using weak will now provide a compilation error that it cannot convert from the strong reference to weak. Validated this fix against GTK 3.34, Vala 0.46+, new libsoup, etc.