### PR TITLE
Updated AppStream metadata file location

### DIFF
--- a/data/com.github.cybre.budgie-haste-applet.appdata.xml
+++ b/data/com.github.cybre.budgie-haste-applet.appdata.xml
@@ -3,7 +3,7 @@
   <id>com.github.cybre.budgie-haste-applet</id>
   <pkgname>budgie-haste-applet</pkgname>
   <translation type="gettext">budgie-haste-applet</translation>
-  <metadata_license>CC0-1.0</metadata_license>
+  <metadata_license>GPL-2.0+</metadata_license>
   <project_license>GPL-2.0+</project_license>
   <name>Budgie Haste Applet</name>
   <summary>Post any text, be it code or prose, to various services directly from your desktop</summary>

--- a/data/meson.build
+++ b/data/meson.build
@@ -7,6 +7,6 @@ install_data('com.github.cybre.budgie-haste-applet.gschema.xml',
              install_dir: join_paths(datadir, 'glib-2.0' ,'schemas'))
 
 install_data('com.github.cybre.budgie-haste-applet.appdata.xml',
-             install_dir: join_paths(datadir, 'appdata'))
+             install_dir: join_paths(datadir, 'metainfo'))
 
 meson.add_install_script('meson_post_install.py')


### PR DESCRIPTION
AppStream metadata file was found in /usr/share/appdata/. The AppStream XML files should be placed in /usr/share/metainfo/.